### PR TITLE
fix(provider): improve thirdweb agent name extraction from description fallback

### DIFF
--- a/src/components/store/agent-card.tsx
+++ b/src/components/store/agent-card.tsx
@@ -55,7 +55,10 @@ export function AgentCard({ agent, availabilityOverride }: AgentCardProps) {
             <div className="flex items-start justify-between gap-4">
               <div className="flex-1 space-y-1">
                 <div className="flex items-center gap-2">
-                  <CardTitle className="text-lg line-clamp-1">
+                  <CardTitle
+                    className="text-lg line-clamp-1"
+                    title={agent.name}
+                  >
                     {agent.name}
                   </CardTitle>
                   <AvailabilityDot isOnline={isOnline} latencyMs={latencyMs} />

--- a/src/lib/providers/thirdweb-adapter.test.ts
+++ b/src/lib/providers/thirdweb-adapter.test.ts
@@ -324,4 +324,127 @@ describe("ThirdwebAdapter", () => {
       statusCode: 0,
     });
   });
+
+  it("uses accepts description as name when metadata.name is missing", () => {
+    const adapter = new ThirdwebAdapter({ secretKey: "sk_test_123" });
+
+    const unified = adapter.normalize(
+      {
+        resource: "https://coinrailz.com/api",
+        type: "http",
+        x402Version: 1,
+        accepts: [
+          {
+            scheme: "exact" as const,
+            network: "eip155:8453",
+            maxAmountRequired: "10000",
+            resource: "https://coinrailz.com/api",
+            description: "Coin Railz x402 Micropayment Services",
+            mimeType: "application/json",
+            payTo: PAY_TO,
+            maxTimeoutSeconds: 60,
+            asset: BASE_USDC,
+          },
+        ],
+        lastUpdated: "2026-02-25T12:00:00Z",
+      },
+      0
+    );
+
+    expect(unified.name).toBe("Coin Railz x402 Micropayment Services");
+  });
+
+  it("prefers metadata.name over accepts description", () => {
+    const adapter = new ThirdwebAdapter({ secretKey: "sk_test_123" });
+
+    const unified = adapter.normalize(
+      {
+        resource: "https://coinrailz.com/api",
+        type: "http",
+        x402Version: 1,
+        accepts: [
+          {
+            scheme: "exact" as const,
+            network: "eip155:8453",
+            maxAmountRequired: "10000",
+            resource: "https://coinrailz.com/api",
+            description: "Coin Railz x402 Micropayment Services",
+            mimeType: "application/json",
+            payTo: PAY_TO,
+            maxTimeoutSeconds: 60,
+            asset: BASE_USDC,
+          },
+        ],
+        lastUpdated: "2026-02-25T12:00:00Z",
+        metadata: { name: "My Custom Agent" },
+      },
+      0
+    );
+
+    expect(unified.name).toBe("My Custom Agent");
+  });
+
+  it("strips URLs and HTTP methods from description when used as name", () => {
+    const adapter = new ThirdwebAdapter({ secretKey: "sk_test_123" });
+
+    const unified = adapter.normalize(
+      {
+        resource: "https://example.com/api",
+        type: "http",
+        x402Version: 1,
+        accepts: [
+          {
+            scheme: "exact" as const,
+            network: "eip155:8453",
+            maxAmountRequired: "10000",
+            resource: "https://example.com/api",
+            description:
+              "Nice project https://nexus.thirdweb.com/routes/31 - GET WeatherData",
+            mimeType: "application/json",
+            payTo: PAY_TO,
+            maxTimeoutSeconds: 60,
+            asset: BASE_USDC,
+          },
+        ],
+        lastUpdated: "2026-02-25T12:00:00Z",
+      },
+      0
+    );
+
+    expect(unified.name).not.toContain("https://");
+    expect(unified.name).not.toMatch(/\bGET\b/);
+    expect(unified.name).toContain("Nice project");
+    expect(unified.name).toContain("WeatherData");
+  });
+
+  it("truncates very long descriptions used as name", () => {
+    const adapter = new ThirdwebAdapter({ secretKey: "sk_test_123" });
+    const longDesc = "A".repeat(100);
+
+    const unified = adapter.normalize(
+      {
+        resource: "https://example.com/api",
+        type: "http",
+        x402Version: 1,
+        accepts: [
+          {
+            scheme: "exact" as const,
+            network: "eip155:8453",
+            maxAmountRequired: "10000",
+            resource: "https://example.com/api",
+            description: longDesc,
+            mimeType: "application/json",
+            payTo: PAY_TO,
+            maxTimeoutSeconds: 60,
+            asset: BASE_USDC,
+          },
+        ],
+        lastUpdated: "2026-02-25T12:00:00Z",
+      },
+      0
+    );
+
+    expect(unified.name.length).toBeLessThanOrEqual(60);
+    expect(unified.name).toContain("…");
+  });
 });

--- a/src/lib/providers/thirdweb-adapter.ts
+++ b/src/lib/providers/thirdweb-adapter.ts
@@ -200,6 +200,25 @@ function normalizeMethod(value: string | undefined): "GET" | "POST" {
   return value?.toUpperCase() === "POST" ? "POST" : "GET";
 }
 
+const MAX_SHORT_NAME_LENGTH = 60;
+const MIN_SHORT_NAME_LENGTH = 3;
+
+// Extract a human-readable short name from a description string
+function extractShortName(raw: string | undefined): string | undefined {
+  if (!raw || raw.trim().length === 0) return undefined;
+
+  const cleaned = raw
+    .replace(/https?:\/\/[^\s]+/g, "") // strip URLs
+    .replace(/\b(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)\b/g, "") // strip HTTP methods
+    .replace(/[\s-]+/g, " ") // collapse whitespace
+    .trim();
+
+  if (cleaned.length < MIN_SHORT_NAME_LENGTH) return undefined;
+
+  if (cleaned.length <= MAX_SHORT_NAME_LENGTH) return cleaned;
+  return cleaned.slice(0, MAX_SHORT_NAME_LENGTH - 1).trimEnd() + "…";
+}
+
 function sanitizeId(value: string): string {
   const normalized = value
     .toLowerCase()
@@ -384,7 +403,10 @@ export class ThirdwebAdapter implements ProviderAdapter {
       id: `thirdweb:${originalId}`,
       provider: "thirdweb" as const,
       originalId,
-      name: readString(metadata, "name") ?? `Nexus Resource: ${nameFromUrl}`,
+      name:
+        readString(metadata, "name") ??
+        extractShortName(accepts?.description) ??
+        `Nexus Resource: ${nameFromUrl}`,
       description:
         accepts?.description ||
         readString(metadata, "description") ||


### PR DESCRIPTION
## Summary

All Thirdweb agents displayed as "Nexus Resource:..." because `metadata.name` is almost never populated by the x402 Discovery API. This PR improves the name fallback chain to extract meaningful names from `accepts[0].description`.

## Changes

### Provider — thirdweb-adapter.ts
- Add `extractShortName()` helper: strips URLs and HTTP methods from description, caps at 60 chars
- Update `normalize()` fallback: `metadata.name` → `extractShortName(description)` → `Nexus Resource: hostname`

### UI — agent-card.tsx
- Add `title` attribute to `CardTitle` for hover tooltip when `line-clamp-1` truncates

## Breaking Changes
- None

## Testing
- 13 tests passed (9 existing + 4 new)
- New tests cover: description fallback, metadata.name priority, URL/method stripping, long name truncation

## Commits
| Commit | Description |
|--------|-------------|
| `54108af` | fix(provider): improve thirdweb agent name extraction from description fallback |